### PR TITLE
feat: add approximate nearest neighbor search

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Think of it as a **cognitive layer**—a memory that fades, reinforces, and rank
 * **REST API Interface**
   Easily insert, query, decay, or reinforce memory via HTTP endpoints like `/insert`, `/query`, `/tick`, `/reinforce`.
 
+* **Approximate Nearest Neighbor (ANN) index**
+  Busca vetores semelhantes de forma acelerada usando hashing sensível à localidade.
+
 * **Lightweight Persistence**
   Default storage is in-memory + JSON file. Alternately supports pluggable store (e.g., Redis, SQLite).
 
@@ -106,7 +109,6 @@ Returns a list of ideas sorted by `v` — the higher the `v`, the more present t
 We have a roadmap for enhancing EidosDB including:
 
 * Integration with real semantic models for generating `vector`s
-* Approximate Nearest Neighbor (ANN) acceleration for fast search
 * Symbolic clustering, TTL/expiration, context-aware snapshots
 * GUI dashboard, real-time reinforcement streams, and more
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,7 @@
 ---
 
 ## 🚧 CORE DEVELOPMENT
-- [ ] Add ANN (Approximate Nearest Neighbor) for high-speed vector search
+ - [x] Add ANN (Approximate Nearest Neighbor) for high-speed vector search
 - [ ] Implement vector similarity fallback (cosine or dot-product)
 - [ ] Enable symbolic clustering / selectors (filters by context, metadata, tags)
 - [ ] Enable symbolic snapshots (dump + restore states)

--- a/eidosdb/src/semantic/annIndex.ts
+++ b/eidosdb/src/semantic/annIndex.ts
@@ -1,0 +1,87 @@
+// src/semantic/annIndex.ts
+import { SemanticIdea } from "../core/symbolicTypes";
+import { cosineSimilarity } from "./similarity";
+
+/**
+ * Índice de vizinhança aproximada baseado em LSH (Locality Sensitive Hashing).
+ * Utiliza hiperplanos aleatórios para particionar o espaço vetorial.
+ * Ideias que caem no mesmo bucket têm grande chance de estar próximas.
+ */
+export class AnnIndex {
+  private tables: Map<string, SemanticIdea[]>[] = [];
+  private projections: number[][][] = [];
+
+  constructor(
+    private dimensions: number,
+    private numTables: number = 4,
+    private numHyperplanes: number = 10
+  ) {
+    // Pré-geração de hiperplanos aleatórios para cada tabela.
+    for (let t = 0; t < numTables; t++) {
+      this.tables.push(new Map());
+      const planes: number[][] = [];
+      for (let h = 0; h < numHyperplanes; h++) {
+        planes.push(
+          Array.from({ length: dimensions }, () => Math.random() * 2 - 1)
+        );
+      }
+      this.projections.push(planes);
+    }
+  }
+
+  /**
+     * Adiciona uma ideia ao índice, calculando o hash em todas as tabelas.
+     */
+  add(idea: SemanticIdea): void {
+    for (let t = 0; t < this.numTables; t++) {
+      const hash = this.hash(idea.vector, t);
+      const bucket = this.tables[t].get(hash) ?? [];
+      bucket.push(idea);
+      this.tables[t].set(hash, bucket);
+    }
+  }
+
+  /**
+   * Constrói o índice com uma lista de ideias.
+   */
+  build(ideas: SemanticIdea[]): void {
+    ideas.forEach((i) => this.add(i));
+  }
+
+  /**
+   * Consulta aproximada: busca candidatos nos buckets correspondentes
+   * e avalia apenas esse subconjunto com similaridade de cosseno.
+   */
+  query(queryVector: number[], topK = 5): SemanticIdea[] {
+    const candidates = new Set<SemanticIdea>();
+    for (let t = 0; t < this.numTables; t++) {
+      const hash = this.hash(queryVector, t);
+      const bucket = this.tables[t].get(hash);
+      if (bucket) bucket.forEach((i) => candidates.add(i));
+    }
+    const list = Array.from(candidates);
+    if (list.length === 0) return [];
+
+    return list
+      .map((idea) => ({
+        idea,
+        score: cosineSimilarity(idea.vector, queryVector),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK)
+      .map((e) => e.idea);
+  }
+
+  /**
+   * Calcula o hash de LSH para um vetor em uma tabela específica.
+   */
+  private hash(vector: number[], tableIndex: number): string {
+    const planes = this.projections[tableIndex];
+    let bits = "";
+    for (const plane of planes) {
+      const dot = vector.reduce((sum, v, i) => sum + v * plane[i], 0);
+      bits += dot >= 0 ? "1" : "0";
+    }
+    return bits;
+  }
+}

--- a/eidosdb/src/semantic/similarity.ts
+++ b/eidosdb/src/semantic/similarity.ts
@@ -1,0 +1,13 @@
+// src/semantic/similarity.ts
+// Funções utilitárias para cálculo de similaridade vetorial.
+
+/**
+ * Calcula a similaridade de cosseno entre dois vetores numéricos.
+ * Retorna um valor entre -1 e 1 que indica o quão alinhados estão.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  const dot = a.reduce((sum, ai, i) => sum + ai * b[i], 0);
+  const normA = Math.sqrt(a.reduce((sum, ai) => sum + ai * ai, 0));
+  const normB = Math.sqrt(b.reduce((sum, bi) => sum + bi * bi, 0));
+  return dot / (normA * normB + 1e-8);
+}


### PR DESCRIPTION
## Summary
- implement LSH-based ANN index for faster vector lookups with Portuguese comments
- expose approximate nearest neighbor search helper
- document ANN capability and mark roadmap task complete

## Testing
- `npm test` (fails: Error: no test specified)
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6891eda57ddc832f8500529d75392eb5