### PR TITLE
feat: add vector similarity fallback

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,7 +23,7 @@
 
 ## 🚧 CORE DEVELOPMENT
  - [x] Add ANN (Approximate Nearest Neighbor) for high-speed vector search
-- [ ] Implement vector similarity fallback (cosine or dot-product)
+- [x] Implement vector similarity fallback (cosine or dot-product)
 - [ ] Enable symbolic clustering / selectors (filters by context, metadata, tags)
 - [ ] Enable symbolic snapshots (dump + restore states)
 - [ ] Implement TTL (time-to-live) or symbolic expiration

--- a/eidosdb/src/semantic/annIndex.ts
+++ b/eidosdb/src/semantic/annIndex.ts
@@ -1,6 +1,6 @@
 // src/semantic/annIndex.ts
 import { SemanticIdea } from "../core/symbolicTypes";
-import { cosineSimilarity } from "./similarity";
+import { vectorSimilarity } from "./similarity";
 
 /**
  * Índice de vizinhança aproximada baseado em LSH (Locality Sensitive Hashing).
@@ -50,7 +50,8 @@ export class AnnIndex {
 
   /**
    * Consulta aproximada: busca candidatos nos buckets correspondentes
-   * e avalia apenas esse subconjunto com similaridade de cosseno.
+   * e avalia apenas esse subconjunto com similaridade vetorial
+   * (cosseno com fallback para dot product).
    */
   query(queryVector: number[], topK = 5): SemanticIdea[] {
     const candidates = new Set<SemanticIdea>();
@@ -65,7 +66,7 @@ export class AnnIndex {
     return list
       .map((idea) => ({
         idea,
-        score: cosineSimilarity(idea.vector, queryVector),
+        score: vectorSimilarity(idea.vector, queryVector),
       }))
       .sort((a, b) => b.score - a.score)
       .slice(0, topK)

--- a/eidosdb/src/semantic/semanticSearch.ts
+++ b/eidosdb/src/semantic/semanticSearch.ts
@@ -1,11 +1,12 @@
 // src/semantic/semanticSearch.ts
 import { SemanticIdea } from "../core/symbolicTypes";
-import { cosineSimilarity } from "./similarity";
+import { vectorSimilarity } from "./similarity";
 import { AnnIndex } from "./annIndex";
 
 /**
- * Busca exata de vizinhos mais próximos utilizando similaridade de cosseno.
- * Útil para conjuntos pequenos de vetores.
+ * Busca exata de vizinhos mais próximos utilizando similaridade vetorial
+ * (cosseno com fallback para dot product). Útil para conjuntos pequenos
+ * de vetores.
  */
 export function findNearestIdeas(
   ideas: SemanticIdea[],
@@ -15,7 +16,7 @@ export function findNearestIdeas(
   return ideas
     .map((idea) => ({
       idea,
-      score: cosineSimilarity(idea.vector, queryVector),
+      score: vectorSimilarity(idea.vector, queryVector),
     }))
     .sort((a, b) => b.score - a.score)
     .slice(0, topK)

--- a/eidosdb/src/semantic/similarity.ts
+++ b/eidosdb/src/semantic/similarity.ts
@@ -2,12 +2,38 @@
 // Funções utilitárias para cálculo de similaridade vetorial.
 
 /**
+ * Calcula o produto escalar entre dois vetores.
+ * Útil como medida de similaridade simples ou como fallback.
+ */
+export function dotProduct(a: number[], b: number[]): number {
+  return a.reduce((sum, ai, i) => sum + ai * b[i], 0);
+}
+
+/**
  * Calcula a similaridade de cosseno entre dois vetores numéricos.
  * Retorna um valor entre -1 e 1 que indica o quão alinhados estão.
+ * Se a norma de algum vetor for zero, realiza fallback para o
+ * produto escalar simples.
  */
 export function cosineSimilarity(a: number[], b: number[]): number {
-  const dot = a.reduce((sum, ai, i) => sum + ai * b[i], 0);
+  const dot = dotProduct(a, b);
   const normA = Math.sqrt(a.reduce((sum, ai) => sum + ai * ai, 0));
   const normB = Math.sqrt(b.reduce((sum, bi) => sum + bi * bi, 0));
-  return dot / (normA * normB + 1e-8);
+  const denom = normA * normB;
+  return denom === 0 ? dot : dot / (denom + 1e-8);
 }
+
+/**
+ * Similaridade vetorial genérica com fallback.
+ * Por padrão usa o cosseno; se esse cálculo não for válido,
+ * recorre ao produto escalar (dot product).
+ */
+export function vectorSimilarity(
+  a: number[],
+  b: number[],
+  method: "cosine" | "dot" = "cosine"
+): number {
+  if (method === "dot") return dotProduct(a, b);
+  return cosineSimilarity(a, b);
+}
+


### PR DESCRIPTION
## Summary
- add dotProduct utility and cosine similarity fallback to vectorSimilarity
- use vectorSimilarity in ANN and semantic search
- mark roadmap task complete

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891f38f5fb0832fa03367fc33584d34