### PR TITLE
feat: add symbolic selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Think of it as a **cognitive layer**—a memory that fades, reinforces, and rank
 
   * a semantic embedding (vector),
   * a symbolic frequency (`w`),
-  * a symbolic distance (`r`),
-  * and contextual metadata (e.g., emotion, origin, type).
+ * a symbolic distance (`r`),
+  * contextual metadata (e.g., emotion, origin, type),
+  * and optional tags for symbolic grouping.
 
 * **Physics-Inspired Presence Formula**
 
@@ -72,7 +73,7 @@ EidosDB is ideal for:
 Endpoints include:
 
 * `POST /insert` → Insert an idea
-* `GET /query?w=0.003` → Rank by symbolic presence
+* `GET /query?w=0.003&context=philosophy&tags=time` → Rank by symbolic presence with selectors
 * `POST /tick` → Apply decay cycle
 * `POST /reinforce` → Reinforce an idea
 * `GET /dump` → Dump raw memory
@@ -89,18 +90,19 @@ const idea: SemanticIdea = {
   w: 0.002,
   r: 2000,
   context: "philosophy",
-  metadata: { emotion: "wonder", origin: "thought experiment" }
+  metadata: { emotion: "wonder", origin: "thought experiment" },
+  tags: ["time", "concept"],
 };
 await api.post('/insert', idea);
 ```
 
-To query memory presence:
+To query memory presence with selectors:
 
 ```bash
-GET /query?w=0.003
+GET /query?w=0.003&context=philosophy&tags=time
 ```
 
-Returns a list of ideas sorted by `v` — the higher the `v`, the more present the idea is right now.
+Returns a list of ideas sorted by `v` — the higher the `v`, the more present the idea is right now and matching the provided filters.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,9 +22,9 @@
 ---
 
 ## 🚧 CORE DEVELOPMENT
- - [x] Add ANN (Approximate Nearest Neighbor) for high-speed vector search
+- [x] Add ANN (Approximate Nearest Neighbor) for high-speed vector search
 - [x] Implement vector similarity fallback (cosine or dot-product)
-- [ ] Enable symbolic clustering / selectors (filters by context, metadata, tags)
+- [x] Enable symbolic clustering / selectors (filters by context, metadata, tags)
 - [ ] Enable symbolic snapshots (dump + restore states)
 - [ ] Implement TTL (time-to-live) or symbolic expiration
 - [ ] Export to Redis or SQLite as pluggable storage option

--- a/eidosdb/src/api/server.ts
+++ b/eidosdb/src/api/server.ts
@@ -12,42 +12,34 @@ console.log("🧠 Memória simbólica carregada do disco.");
 app.use(cors());
 app.use(bodyParser.json());
 
-// Rota para consulta por v
+// Rota para consulta por v com seletores simbólicos
 app.get("/query", (req, res) => {
   const w = parseFloat(req.query.w as string);
   if (isNaN(w)) return res.status(400).send("Missing or invalid 'w'");
 
-  const result = store.query(w);
+  const c = req.query.c ? parseFloat(req.query.c as string) : undefined;
+  const context = req.query.context as string | undefined;
+
+  const tagsParam = req.query.tags as string | undefined;
+  const tags = tagsParam
+    ? tagsParam
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0)
+    : undefined;
+
+  const metadataParam = req.query.metadata as string | undefined;
+  let metadata: Record<string, any> | undefined;
+  if (metadataParam) {
+    try {
+      metadata = JSON.parse(metadataParam);
+    } catch {
+      return res.status(400).send("Invalid 'metadata' JSON");
+    }
+  }
+
+  const result = store.query(w, c, { context, tags, metadata });
   res.json(result);
-});
-
-// Rota simbólica com filtro por metadata
-app.get("/query-simbolica", (req, res) => {
-  const w = parseFloat(req.query.w as string);
-  if (isNaN(w)) return res.status(400).send("Missing or invalid 'w'");
-
-  // Extração dos filtros opcionais
-  const filtroTipo = req.query.tipo as string | undefined;
-  const filtroEmocao = req.query.emoção as string | undefined;
-  const filtroOrigem = req.query.origem as string | undefined;
-  const filtroRelacao = req.query.relação as string | undefined;
-
-  // Avaliar e ordenar por v
-  const avaliados = store.query(w);
-
-  // Aplicar filtros simbólicos
-  const filtrados = avaliados.filter((p) => {
-    const m = p.metadata ?? {};
-
-    if (filtroTipo && m.tipo !== filtroTipo) return false;
-    if (filtroOrigem && m.origem !== filtroOrigem) return false;
-    if (filtroEmocao && !m.emoções?.includes(filtroEmocao)) return false;
-    if (filtroRelacao && !m.relações?.includes(filtroRelacao)) return false;
-
-    return true;
-  });
-
-  res.json(filtrados);
 });
 
 // Inserção de novo ponto

--- a/eidosdb/src/core/symbolicTypes.ts
+++ b/eidosdb/src/core/symbolicTypes.ts
@@ -9,6 +9,7 @@ export interface SemanticIdea {
   context: string; // Nome do cluster (ex: "futuro", "medo")
   timestamp?: number; // Momento de inserção ou ativação
   metadata?: Record<string, any>; // Emoção, tipo, origem, etc.
+  tags?: string[]; // Marcadores simbólicos adicionais
 }
 
 export interface QueryParams {
@@ -20,4 +21,10 @@ export interface QueryParams {
 
 export interface EvaluatedIdea extends SemanticIdea {
   v: number; // Presença simbólica (calculada)
+}
+
+export interface QuerySelectors {
+  context?: string;
+  metadata?: Record<string, any>;
+  tags?: string[];
 }


### PR DESCRIPTION
## Summary
- extend SemanticIdea with optional tags and introduce QuerySelectors interface
- filter queries by context, metadata, and tags in EidosStore
- expose selector-based querying via `/query` endpoint and update docs

## Testing
- `npm test` (fails: Error: no test specified)
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6891f52f022c832f879e3decca2930b2