### PR TITLE
Add symbolic snapshot and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ Endpoints include:
 * `GET /query?w=0.003&context=philosophy&tags=time` → Rank by symbolic presence with selectors
 * `POST /tick` → Apply decay cycle
 * `POST /reinforce` → Reinforce an idea
-* `GET /dump` → Dump raw memory
+* `GET /dump` → Dump memory snapshot
+* `POST /restore` → Restore memory from a snapshot
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -25,7 +25,7 @@
 - [x] Add ANN (Approximate Nearest Neighbor) for high-speed vector search
 - [x] Implement vector similarity fallback (cosine or dot-product)
 - [x] Enable symbolic clustering / selectors (filters by context, metadata, tags)
-- [ ] Enable symbolic snapshots (dump + restore states)
+- [x] Enable symbolic snapshots (dump + restore states)
 - [ ] Implement TTL (time-to-live) or symbolic expiration
 - [ ] Export to Redis or SQLite as pluggable storage option
 - [ ] Stream-based reinforcement (via websocket or Kafka)

--- a/eidosdb/src/api/server.ts
+++ b/eidosdb/src/api/server.ts
@@ -67,9 +67,19 @@ app.post("/reinforce", (req, res) => {
   res.send("Reinforced");
 });
 
-// Dump da memória
+// Dump/Snapshot da memória atual
 app.get("/dump", (_req, res) => {
-  res.json(store.dump());
+  res.json(store.snapshot());
+});
+
+// Restaura o estado da memória a partir de um snapshot enviado
+app.post("/restore", (req, res) => {
+  const snapshot: SemanticIdea[] = req.body;
+  if (!Array.isArray(snapshot)) {
+    return res.status(400).send("Invalid snapshot format");
+  }
+  store.restore(snapshot);
+  res.send("Snapshot restored");
 });
 
 // Salvar

--- a/eidosdb/src/storage/symbolicStore.ts
+++ b/eidosdb/src/storage/symbolicStore.ts
@@ -108,9 +108,26 @@ export class EidosStore {
   }
 
   /**
+   * Cria um snapshot profundo da memória atual.
+   * Retorna uma cópia independente para evitar mutações externas.
+   */
+  snapshot(): SemanticIdea[] {
+    return this.memory.map((idea) => ({ ...idea }));
+  }
+
+  /**
+   * Restaura o estado da memória a partir de um snapshot.
+   * Todo conteúdo existente é substituído pelo snapshot fornecido.
+   */
+  restore(snapshot: SemanticIdea[]): void {
+    this.memory = snapshot.map((idea) => ({ ...idea }));
+  }
+
+  /**
    * Retorna todas as ideias sem avaliação (estado bruto).
+   * Mantido como alias para `snapshot()` por compatibilidade.
    */
   dump(): SemanticIdea[] {
-    return [...this.memory];
+    return this.snapshot();
   }
 }


### PR DESCRIPTION
## Summary
- allow taking and restoring in-memory snapshots of symbolic ideas
- expose `/restore` endpoint and document snapshot usage
- mark snapshot feature as complete in TODO

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_689268b2c264832faeb28cc8f8ac0d1d