### PR TITLE
feat: add TTL expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Think of it as a **cognitive layer**—a memory that fades, reinforces, and rank
 
   * **Decay over time** (`tick()` lowers `w`)
   * **Reinforcement** (`reinforce(id)`) to boost an idea
+  * **Symbolic expiration** through per-idea TTL
   * **Context-based filtering** and search
 
 * **REST API Interface**
@@ -112,7 +113,7 @@ Returns a list of ideas sorted by `v` — the higher the `v`, the more present t
 We have a roadmap for enhancing EidosDB including:
 
 * Integration with real semantic models for generating `vector`s
-* Symbolic clustering, TTL/expiration, context-aware snapshots
+* Symbolic clustering, context-aware snapshots
 * GUI dashboard, real-time reinforcement streams, and more
 
 We welcome contributors! See the `TODO.md` for high-level tasks and issue ideas.

--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,7 @@
 - [x] Implement vector similarity fallback (cosine or dot-product)
 - [x] Enable symbolic clustering / selectors (filters by context, metadata, tags)
 - [x] Enable symbolic snapshots (dump + restore states)
-- [ ] Implement TTL (time-to-live) or symbolic expiration
+- [x] Implement TTL (time-to-live) or symbolic expiration
 - [ ] Export to Redis or SQLite as pluggable storage option
 - [ ] Stream-based reinforcement (via websocket or Kafka)
 - [ ] Optimize decay loop for GPU (optional)

--- a/eidosdb/src/api/server.ts
+++ b/eidosdb/src/api/server.ts
@@ -43,6 +43,7 @@ app.get("/query", (req, res) => {
 });
 
 // Inserção de novo ponto
+// Permite campo opcional `ttl` (ms) para expirar automaticamente a ideia
 app.post("/insert", (req, res) => {
   const data: SemanticIdea = req.body;
   if (!data.id || typeof data.w !== "number" || typeof data.r !== "number") {

--- a/eidosdb/src/core/symbolicTypes.ts
+++ b/eidosdb/src/core/symbolicTypes.ts
@@ -8,6 +8,7 @@ export interface SemanticIdea {
   r: number; // Distância simbólica (contexto)
   context: string; // Nome do cluster (ex: "futuro", "medo")
   timestamp?: number; // Momento de inserção ou ativação
+  ttl?: number; // Tempo de vida em ms antes de expirar
   metadata?: Record<string, any>; // Emoção, tipo, origem, etc.
   tags?: string[]; // Marcadores simbólicos adicionais
 }

--- a/eidosdb/src/semantic/semanticStore.ts
+++ b/eidosdb/src/semantic/semanticStore.ts
@@ -5,7 +5,29 @@ export class SemanticStore {
   private ideasById = new Map<string, SemanticIdea>();
   private ideasByContext = new Map<string, SemanticIdea[]>();
 
+  /**
+   * Remove entradas expiradas de ambos os mapas.
+   */
+  private cleanupExpired(): void {
+    const now = Date.now();
+    for (const [id, idea] of this.ideasById) {
+      if (idea.ttl && idea.timestamp && idea.timestamp + idea.ttl <= now) {
+        this.ideasById.delete(id);
+        const arr = this.ideasByContext.get(idea.context);
+        if (arr) {
+          const idx = arr.findIndex((i) => i.id === id);
+          if (idx !== -1) arr.splice(idx, 1);
+          if (arr.length === 0) this.ideasByContext.delete(idea.context);
+        }
+      }
+    }
+  }
+
   insert(idea: SemanticIdea) {
+    this.cleanupExpired();
+    if (!idea.timestamp) {
+      idea.timestamp = Date.now();
+    }
     this.ideasById.set(idea.id, idea);
     if (!this.ideasByContext.has(idea.context)) {
       this.ideasByContext.set(idea.context, []);
@@ -14,14 +36,17 @@ export class SemanticStore {
   }
 
   getById(id: string): SemanticIdea | undefined {
+    this.cleanupExpired();
     return this.ideasById.get(id);
   }
 
   getByContext(context: string): SemanticIdea[] {
+    this.cleanupExpired();
     return this.ideasByContext.get(context) || [];
   }
 
   getAll(): SemanticIdea[] {
+    this.cleanupExpired();
     return [...this.ideasById.values()];
   }
 }

--- a/eidosdb/src/semantic/tick.ts
+++ b/eidosdb/src/semantic/tick.ts
@@ -6,7 +6,12 @@ export function applyDecay(
   decayFactor: number = 0.99,
   minThreshold: number = 0.001
 ): SemanticIdea[] {
+  const now = Date.now();
   return ideas.filter((idea) => {
+    // Expira ideias cujo tempo de vida (timestamp + ttl) foi atingido
+    if (idea.ttl && idea.timestamp && idea.timestamp + idea.ttl <= now) {
+      return false;
+    }
     idea.w *= decayFactor;
     return idea.w >= minThreshold;
   });

--- a/eidosdb/src/storage/memoryStore.ts
+++ b/eidosdb/src/storage/memoryStore.ts
@@ -9,9 +9,26 @@ import { calculateV, DEFAULT_C } from "../core/formula";
 const ideaStore: SemanticIdea[] = [];
 
 /**
+ * Remove ideias expiradas baseadas em timestamp + ttl.
+ */
+function cleanupExpired() {
+  const now = Date.now();
+  for (let i = ideaStore.length - 1; i >= 0; i--) {
+    const idea = ideaStore[i];
+    if (idea.ttl && idea.timestamp && idea.timestamp + idea.ttl <= now) {
+      ideaStore.splice(i, 1);
+    }
+  }
+}
+
+/**
  * Insere uma nova ideia simbólica no banco.
  */
 export function insertIdea(idea: SemanticIdea): void {
+  cleanupExpired();
+  if (!idea.timestamp) {
+    idea.timestamp = Date.now();
+  }
   ideaStore.push(idea);
 }
 
@@ -22,6 +39,7 @@ export function queryIdeasByW(
   w: number,
   c: number = DEFAULT_C
 ): (SemanticIdea & { v: number })[] {
+  cleanupExpired();
   return ideaStore
     .map((idea) => ({
       ...idea,


### PR DESCRIPTION
## Summary
- add optional TTL field to ideas for symbolic expiration
- prune expired ideas automatically in memory stores and during decay
- document TTL feature and mark todo complete

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68926b31b1d0832fb20e4bcd6deb22a6