### PR TITLE
Add optional GPU accelerated decay loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Think of it as a **cognitive layer**—a memory that fades, reinforces, and rank
 * **Lightweight Persistence**
   Default storage is in-memory + JSON file. Alternately supports pluggable store (e.g., Redis, SQLite).
 
+* **Optional GPU Decay Loop**
+  Weight decay can leverage GPU.js when installed, falling back to the CPU otherwise.
+
 ---
 
 ## 🧠 Why It Matters
@@ -89,6 +92,18 @@ Endpoints include:
 Set the `EIDOS_STORAGE` variable to `memory` (default), `redis`, or `sqlite` before starting the server.
 To use Redis, install the package and run an available Redis server.
 For SQLite, `npm install` compiles the `better-sqlite3` module without the need for an external service.
+
+---
+
+## ⚡ Optional GPU Acceleration
+
+The decay loop can run on the GPU using [GPU.js](https://github.com/gpujs/gpu.js). Install the library and it will be used automatically:
+
+```bash
+npm install gpu.js
+```
+
+If GPU.js or compatible hardware is unavailable, the system falls back to the CPU implementation.
 
 ---
 

--- a/eidosdb/src/semantic/tick.ts
+++ b/eidosdb/src/semantic/tick.ts
@@ -1,12 +1,48 @@
 // src/semantic/tick.ts
 import { SemanticIdea } from "../core/symbolicTypes";
 
+// Tenta importar GPU.js dinamicamente para uso opcional
+let GPUClass: any;
+try {
+  // Se o pacote não estiver instalado, permanece undefined
+  GPUClass = require("gpu.js").GPU;
+} catch {
+  GPUClass = undefined;
+}
+
 export function applyDecay(
   ideas: SemanticIdea[],
   decayFactor: number = 0.99,
   minThreshold: number = 0.001
 ): SemanticIdea[] {
   const now = Date.now();
+
+  // Se GPU.js estiver disponível, utiliza a GPU para aplicar o decaimento
+  if (GPUClass) {
+    // Cria kernel que multiplica cada peso pelo fator de decaimento
+    const gpu = new GPUClass();
+    const kernel = gpu
+      .createKernel(function (pesos: number[], fator: number) {
+        // Multiplica cada elemento; this.thread.x indica o índice atual
+        return pesos[this.thread.x] * fator;
+      })
+      .setOutput([ideas.length]);
+
+    const pesos = ideas.map((idea) => idea.w);
+    const resultado = kernel(pesos, decayFactor) as number[];
+
+    return ideas.filter((idea, idx) => {
+      // Expira ideias cujo tempo de vida (timestamp + ttl) foi atingido
+      if (idea.ttl && idea.timestamp && idea.timestamp + idea.ttl <= now) {
+        return false;
+      }
+      // Atualiza o peso com valor processado pela GPU
+      idea.w = resultado[idx];
+      return idea.w >= minThreshold;
+    });
+  }
+
+  // Caminho padrão em CPU caso a GPU não esteja disponível
   return ideas.filter((idea) => {
     // Expira ideias cujo tempo de vida (timestamp + ttl) foi atingido
     if (idea.ttl && idea.timestamp && idea.timestamp + idea.ttl <= now) {


### PR DESCRIPTION
## Summary
- enable GPU.js-accelerated decay when available with automatic CPU fallback
- document optional GPU usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68927d97cbb4832f8ef2ede5cadbd573