### PR TITLE
feat: add API rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Think of it as a **cognitive layer**—a memory that fades, reinforces, and rank
 * **WebSocket reinforcement stream**
   Send real-time reinforcement events through `ws://localhost:3000/reinforce-stream` using JSON payloads.
 
+* **API rate limiting**
+  Requests are capped at 100 per minute per IP to prevent abuse.
+
 * **Approximate Nearest Neighbor (ANN) index**
   Accelerated search for similar vectors using locality-sensitive hashing.
 

--- a/eidosdb/package-lock.json
+++ b/eidosdb/package-lock.json
@@ -16,6 +16,7 @@
         "chartjs-node-canvas": "^5.0.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "redis": "^5.8.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2",
@@ -2953,6 +2954,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3401,6 +3420,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/eidosdb/package.json
+++ b/eidosdb/package.json
@@ -18,6 +18,7 @@
     "chartjs-node-canvas": "^5.0.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "redis": "^5.8.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",

--- a/eidosdb/src/api/server.ts
+++ b/eidosdb/src/api/server.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import bodyParser from "body-parser";
 import cors from "cors";
+import rateLimit from "express-rate-limit";
 import { createServer } from "http"; // Node HTTP server for Express + WebSocket
 import { WebSocketServer } from "ws"; // WebSocket server for streaming reinforcement
 import { EidosStore } from "../storage/symbolicStore";
@@ -32,6 +33,16 @@ store
 
 app.use(cors());
 app.use(bodyParser.json());
+
+// Limitador de taxa para evitar abuso: 100 requisições por minuto por IP
+const limiter = rateLimit({
+  windowMs: 60 * 1000, // Janela de 1 minuto
+  max: 100, // Máximo de 100 requisições por IP
+  standardHeaders: true, // Usa cabeçalhos RateLimit-*
+  legacyHeaders: false, // Desativa cabeçalhos X-RateLimit-*
+});
+
+app.use(limiter);
 
 // Rota para consulta por v com seletores simbólicos
 app.get("/query", async (req, res) => {


### PR DESCRIPTION
## Summary
- limit each IP to 100 requests per minute using `express-rate-limit`
- document API rate limiting feature in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689283f15c10832fb876b12478d51922