### PR TITLE
feat: compute and log symbolic metrics

### DIFF
--- a/eidosdb/src/api/server.ts
+++ b/eidosdb/src/api/server.ts
@@ -10,6 +10,7 @@ import { SQLiteStore } from "../storage/sqliteStore";
 import { MemoryStore } from "../storage/memoryStore";
 import type { StorageAdapter } from "../storage/storageAdapter";
 import type { SemanticIdea } from "../core/symbolicTypes";
+import { logSymbolicMetrics } from "../utils/logger";
 
 const app = express();
 
@@ -83,12 +84,14 @@ app.post("/insert", async (req, res) => {
   }
 
   await store.insert(data);
+  await logSymbolicMetrics(store);
   res.sendStatus(201);
 });
 
 // Tick de decaimento
 app.post("/tick", async (_req, res) => {
   await store.tick();
+  await logSymbolicMetrics(store);
   res.send("Tick applied");
 });
 
@@ -97,6 +100,7 @@ app.post("/reinforce", async (req, res) => {
   const { id, factor } = req.body;
   if (!id) return res.status(400).send("Missing 'id'");
   await store.reinforce(id, factor || 1.1);
+  await logSymbolicMetrics(store);
   res.send("Reinforced");
 });
 

--- a/eidosdb/src/utils/logger.ts
+++ b/eidosdb/src/utils/logger.ts
@@ -1,0 +1,67 @@
+// src/utils/logger.ts
+
+import type { SemanticIdea } from "../core/symbolicTypes";
+import { calculateV, DEFAULT_C } from "../core/formula";
+
+/**
+ * Estrutura de métricas simbólicas calculadas.
+ */
+export interface SymbolicMetrics {
+  averageV: number;
+  dominantCluster: string | null;
+}
+
+/**
+ * Calcula métricas simbólicas como v médio e cluster dominante.
+ */
+export function computeSymbolicMetrics(
+  ideas: SemanticIdea[],
+  c: number = DEFAULT_C,
+): SymbolicMetrics {
+  if (ideas.length === 0) {
+    return { averageV: 0, dominantCluster: null };
+  }
+
+  let sumV = 0;
+  const clusterWeights = new Map<string, number>();
+
+  for (const idea of ideas) {
+    const v = calculateV(idea.w, idea.r, c);
+    sumV += v;
+    clusterWeights.set(
+      idea.context,
+      (clusterWeights.get(idea.context) ?? 0) + idea.w,
+    );
+  }
+
+  let dominantCluster: string | null = null;
+  let maxWeight = -Infinity;
+  for (const [context, weight] of clusterWeights) {
+    if (weight > maxWeight) {
+      dominantCluster = context;
+      maxWeight = weight;
+    }
+  }
+
+  return {
+    averageV: sumV / ideas.length,
+    dominantCluster,
+  };
+}
+
+/**
+ * Faz log das métricas simbólicas atuais do armazenamento.
+ */
+export async function logSymbolicMetrics(
+  provider: { snapshot: () => Promise<SemanticIdea[]> },
+  c: number = DEFAULT_C,
+): Promise<void> {
+  const snapshot = await provider.snapshot();
+  const metrics = computeSymbolicMetrics(snapshot, c);
+  console.log(
+    `📊 v médio: ${metrics.averageV.toFixed(4)} | cluster dominante: ${
+      metrics.dominantCluster ?? "nenhum"
+    }`,
+  );
+}
+

--- a/eidosdb/tests/logger.test.ts
+++ b/eidosdb/tests/logger.test.ts
@@ -1,0 +1,42 @@
+import { computeSymbolicMetrics } from '../src/utils/logger';
+import { calculateV } from '../src/core/formula';
+import type { SemanticIdea } from '../src/core/symbolicTypes';
+
+function createIdea(
+  id: string,
+  w: number,
+  r: number,
+  context: string,
+): SemanticIdea {
+  return {
+    id,
+    label: id,
+    vector: [0],
+    w,
+    r,
+    context,
+  };
+}
+
+test('calcula média de v e cluster dominante', () => {
+  const ideas = [
+    createIdea('a', 0.002, 1, 'alpha'),
+    createIdea('b', 0.004, 2, 'beta'),
+    createIdea('c', 0.003, 1.5, 'beta'),
+  ];
+
+  const metrics = computeSymbolicMetrics(ideas);
+  const expectedAvg =
+    (calculateV(0.002, 1) + calculateV(0.004, 2) + calculateV(0.003, 1.5)) /
+    3;
+
+  expect(metrics.averageV).toBeCloseTo(expectedAvg);
+  expect(metrics.dominantCluster).toBe('beta');
+});
+
+test('retorna métricas neutras quando vazio', () => {
+  const metrics = computeSymbolicMetrics([]);
+  expect(metrics.averageV).toBe(0);
+  expect(metrics.dominantCluster).toBeNull();
+});
+


### PR DESCRIPTION
## Summary
- add utilities to compute symbolic metrics (average v and dominant cluster) and log them
- log metrics after inserts, ticks, and reinforcements in the API server
- cover metrics computation with new unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689287de734c832fbdc9274e0df9ebe8