### PR TITLE
feat: add real-time monitoring dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Think of it as a **cognitive layer**—a memory that fades, reinforces, and rank
 * **WebSocket reinforcement stream**
   Send real-time reinforcement events through `ws://localhost:3000/reinforce-stream` using JSON payloads.
 
+* **Real-time monitoring dashboard**
+  Observe symbolic metrics live at `http://localhost:3000/dashboard`.
+
 * **API rate limiting**
   Requests are capped at 100 per minute per IP to prevent abuse.
 
@@ -79,6 +82,7 @@ EidosDB is ideal for:
    npx ts-node src/api/server.ts
    ```
 4. Access API on [http://localhost:3000](http://localhost:3000)
+5. Open the real-time dashboard at [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
 
 Endpoints include:
 

--- a/eidosdb/src/api/dashboard.html
+++ b/eidosdb/src/api/dashboard.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>EidosDB Dashboard</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <h1>EidosDB Metrics</h1>
+  <p id="cluster">Cluster Dominante: -</p>
+  <canvas id="chart" width="600" height="300"></canvas>
+  <script>
+    // Conecta ao servidor WebSocket para receber métricas em tempo real
+    const socket = new WebSocket('ws://localhost:3000/metrics-stream');
+
+    const ctx = document.getElementById('chart').getContext('2d');
+    // Configuração do gráfico de linha para acompanhar o valor médio de v
+    const chart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: [],
+        datasets: [{
+          label: 'v médio',
+          data: [],
+          borderColor: 'rgba(75,192,192,1)',
+          tension: 0.1
+        }]
+      },
+      options: {
+        animation: false,
+        scales: {
+          x: {
+            title: {
+              display: true,
+              text: 'Leituras'
+            }
+          },
+          y: {
+            title: {
+              display: true,
+              text: 'v'
+            }
+          }
+        }
+      }
+    });
+
+    socket.addEventListener('message', (event) => {
+      // Atualiza o gráfico e o texto com as métricas recebidas
+      const metrics = JSON.parse(event.data);
+      document.getElementById('cluster').textContent = 'Cluster Dominante: ' + (metrics.dominantCluster || '-');
+      chart.data.labels.push('');
+      chart.data.datasets[0].data.push(metrics.averageV);
+      chart.update();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose real-time metrics via WebSocket and serve dashboard
- implement simple HTML/Chart.js dashboard for live symbolic metrics
- document dashboard usage in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68928a0afe48832f96c93d38c44a84b0