### PR TITLE
Add Docker deployment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Imagem base com Node.js
+FROM node:18-alpine
+
+# Definir diretório de trabalho dentro do contêiner
+WORKDIR /app
+
+# Copiar arquivos de dependências para otimizar o cache de build
+COPY eidosdb/package*.json ./
+
+# Instalar dependências sem pacotes de desenvolvimento
+RUN npm ci --omit=dev
+
+# Copiar o restante do código da aplicação
+COPY eidosdb/ .
+
+# Expor a porta utilizada pela API
+EXPOSE 3000
+
+# Comando padrão para iniciar o servidor
+CMD ["npm", "run", "start:api"]

--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ For SQLite, `npm install` compiles the `better-sqlite3` module without the need 
 
 ---
 
+## 🐳 Docker Deployment
+
+Run EidosDB in a container without installing Node.js locally.
+
+```bash
+./deploy.sh
+```
+
+The script builds the Docker image and starts the server on `http://localhost:3000`.
+
+---
+
 ## ⚡ Optional GPU Acceleration
 
 The decay loop can run on the GPU using [GPU.js](https://github.com/gpujs/gpu.js). Install the library and it will be used automatically:

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Script de deploy do EidosDB usando Docker
+
+# Encerrar imediatamente se algum comando falhar
+set -e
+
+IMAGEM="eidosdb"
+CONTAINER="eidosdb_container"
+
+# Remover contêiner existente, se houver
+if [ "$(docker ps -aq -f name=$CONTAINER)" ]; then
+  docker rm -f $CONTAINER
+fi
+
+# Construir a imagem Docker
+docker build -t $IMAGEM .
+
+# Iniciar o contêiner em segundo plano
+docker run -d --name $CONTAINER -p 3000:3000 $IMAGEM


### PR DESCRIPTION
## Summary
- add Dockerfile for containerized EidosDB
- provide deploy.sh script with Portuguese comments
- document Docker usage in README

## Testing
- `npm test`
- `docker build -t eidosdb-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68928b89e4d0832f9a5faaadfe2b5fed