### PR TITLE
Install canvas build dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,16 @@ WORKDIR /app
 # Copiar arquivos de dependências para otimizar o cache de build
 COPY eidosdb/package*.json ./
 
+# Pacotes necessários para build do canvas
+RUN apk add --no-cache \
+    g++ \
+    make \
+    python3 \
+    cairo-dev \
+    pango-dev \
+    jpeg-dev \
+    giflib-dev
+
 # Instalar dependências sem pacotes de desenvolvimento
 RUN npm ci --omit=dev
 


### PR DESCRIPTION
## Summary
- install alpine packages required to build the canvas module in Dockerfile before running `npm ci`

## Testing
- `npm ci --omit=dev`
- Attempted container build with `podman build` (operation not permitted)


------
https://chatgpt.com/codex/tasks/task_e_68928fbcf21c832fada55ce815059e41