### PR TITLE
feat: add runtime license validator

### DIFF
--- a/eidosdb/src/api/server.ts
+++ b/eidosdb/src/api/server.ts
@@ -14,7 +14,9 @@ import type { StorageAdapter } from "../storage/storageAdapter";
 import type { SemanticIdea } from "../core/symbolicTypes";
 import { logSymbolicMetrics, computeSymbolicMetrics } from "../utils/logger";
 import { setupGraphQL } from "./graphqlAdapter"; // Adapta REST para GraphQL
+import { validarLicenca } from "../utils/license";
 
+validarLicenca();
 const app = express();
 
 const storageType = process.env.EIDOS_STORAGE || "memory";

--- a/eidosdb/src/utils/license.ts
+++ b/eidosdb/src/utils/license.ts
@@ -12,3 +12,25 @@ export function carregarLicenca(): string {
   // Retorna o conteúdo do arquivo como string
   return fs.readFileSync(caminho, 'utf-8');
 }
+
+/**
+ * Valida se a licença foi aceita em tempo de execução.
+ * A validação é ignorada quando NODE_ENV === 'test'.
+ * Define a variável de ambiente EIDOS_ACCEPT_LICENSE com
+ * valor 'true' para permitir a execução.
+ */
+export function validarLicenca(): void {
+  if (process.env.NODE_ENV === 'test') return;
+
+  const aceite = process.env.EIDOS_ACCEPT_LICENSE;
+  const aceitos = ['1', 'true', 'yes'];
+  if (aceite && aceitos.includes(aceite.toLowerCase())) return;
+
+  const texto = carregarLicenca();
+  console.error('EidosDB requer a aceitação da licença CC BY-NC 4.0.');
+  console.error(
+    'Defina EIDOS_ACCEPT_LICENSE=true para confirmar que você concorda com os termos.'
+  );
+  console.error(texto);
+  throw new Error('Licença não aceita');
+}

--- a/eidosdb/tests/license.test.ts
+++ b/eidosdb/tests/license.test.ts
@@ -1,0 +1,21 @@
+import { validarLicenca } from "../src/utils/license";
+
+describe("validação de licença", () => {
+  const OLD_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...OLD_ENV };
+  });
+
+  it("lança erro quando licença não é aceita", () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.EIDOS_ACCEPT_LICENSE;
+    expect(() => validarLicenca()).toThrow("Licença não aceita");
+  });
+
+  it("permite execução quando licença é aceita", () => {
+    process.env.NODE_ENV = "production";
+    process.env.EIDOS_ACCEPT_LICENSE = "true";
+    expect(() => validarLicenca()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add runtime license check requiring `EIDOS_ACCEPT_LICENSE`
- hook validation into API server
- cover license acceptance with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a4127d60832f83e98de6d7447a88