### PR TITLE
chore: set license env in docker run

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -16,4 +16,8 @@ fi
 docker build -t $IMAGEM .
 
 # Iniciar o contêiner em segundo plano
-docker run -d --name $CONTAINER -p 3000:3000 $IMAGEM
+docker run -d \
+  --name "$CONTAINER" \
+  -p 3000:3000 \
+  -e EIDOS_ACCEPT_LICENSE=true \
+  "$IMAGEM"


### PR DESCRIPTION
## Summary
- ensure deploy script runs container with license acceptance env

## Testing
- `bash -n deploy.sh`
- `cd eidosdb && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892aa0dc24c832fb3e641996c6c9b7a