### PR TITLE
chore: use node 20 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Imagem base com Node.js
-FROM node:18-alpine
+FROM node:20-alpine
 
 # Definir diretório de trabalho dentro do contêiner
 WORKDIR /app


### PR DESCRIPTION
## Summary
- use node 20 in Dockerfile for better-sqlite3 compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b350b474832f86d8cf82dac0ea4d