### PR TITLE
feat: add interactive dashboard with memory heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ This makes EidosDB ideal for agents that need evolving symbolic knowledge, such 
 * **WebSocket reinforcement stream**
   Send real-time reinforcement events through `ws://localhost:3000/reinforce-stream` using JSON payloads.
 
-* **Real-time monitoring dashboard**
-  Observe symbolic metrics live at `http://localhost:3000/dashboard`.
+* **Interactive real-time dashboard**
+  Observe symbolic metrics live at `http://localhost:3000/dashboard`, now with an embedded browser and memory heatmap for exploration.
 
 * **API rate limiting & usage tracking**
   Requests are limited per API key and total daily usage is monitored.
@@ -126,7 +126,7 @@ EidosDB is ideal for:
    npx ts-node src/api/server.ts
    ```
 4. Access API on [http://localhost:3000](http://localhost:3000)
-5. Open the real-time dashboard at [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
+5. Open the interactive dashboard (embedded browser + memory heatmap) at [http://localhost:3000/dashboard](http://localhost:3000/dashboard)
 
 Endpoints include:
 

--- a/TODO.md
+++ b/TODO.md
@@ -57,7 +57,7 @@
 
 ## 💡 PRODUCT FEATURES
 
-* [ ] Interactive dashboard (embed browser + memory heatmap)
+* [x] Interactive dashboard (embed browser + memory heatmap)
 * [ ] Semantic visualizer: PCA/tSNE of vectors by cluster/context
 * [ ] CLI client for local insert/query/decay
 * [ ] Desktop mini-tool for memory inspection

--- a/eidosdb/src/api/dashboard.html
+++ b/eidosdb/src/api/dashboard.html
@@ -4,11 +4,18 @@
   <meta charset="UTF-8" />
   <title>EidosDB Dashboard</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-matrix@1.3.0"></script>
 </head>
 <body>
   <h1>EidosDB Metrics</h1>
   <p id="cluster">Cluster Dominante: -</p>
   <canvas id="chart" width="600" height="300"></canvas>
+  <h2>Mapa de Calor da Memória</h2>
+  <canvas id="heat" width="300" height="300"></canvas>
+  <h2>Navegador Embutido</h2>
+  <input id="url" type="text" value="https://example.org" size="40" />
+  <button id="go">Carregar</button>
+  <iframe id="browser" width="600" height="400"></iframe>
   <script>
     // Conecta ao servidor WebSocket para receber métricas em tempo real
     const socket = new WebSocket('ws://localhost:3000/metrics-stream');
@@ -52,6 +59,47 @@
       chart.data.labels.push('');
       chart.data.datasets[0].data.push(metrics.averageV);
       chart.update();
+      // Atualiza o mapa de calor com os valores de v recebidos
+      atualizarMapa(metrics.heatmap);
+    });
+
+    // Configuração do mapa de calor usando chartjs-chart-matrix
+    const heatCtx = document.getElementById('heat').getContext('2d');
+    const heatChart = new Chart(heatCtx, {
+      type: 'matrix',
+      data: { datasets: [{ data: [] }] },
+      options: {
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { display: false },
+          y: { display: false },
+        },
+      },
+    });
+
+    // Função para traduzir a matriz de v em dados para o gráfico
+    function atualizarMapa(matriz) {
+      const dados = [];
+      let max = 0;
+      matriz.forEach((linha, y) => {
+        linha.forEach((valor, x) => {
+          if (valor > max) max = valor;
+          dados.push({ x, y, v: valor });
+        });
+      });
+      heatChart.data.datasets[0].data = dados;
+      heatChart.data.datasets[0].backgroundColor = ctx => {
+        const value = ctx.dataset.data[ctx.dataIndex].v;
+        const alpha = max === 0 ? 0 : value / max;
+        return `rgba(255, 0, 0, ${alpha})`;
+      };
+      heatChart.update();
+    }
+
+    // Navegador simples: carrega a URL digitada no iframe
+    document.getElementById('go').addEventListener('click', () => {
+      const url = (document.getElementById('url')).value;
+      document.getElementById('browser').src = url;
     });
   </script>
 </body>

--- a/eidosdb/src/utils/logger.ts
+++ b/eidosdb/src/utils/logger.ts
@@ -9,6 +9,7 @@ import { calculateV, DEFAULT_C } from "../core/formula";
 export interface SymbolicMetrics {
   averageV: number;
   dominantCluster: string | null;
+  heatmap: number[][];
 }
 
 /**
@@ -19,14 +20,18 @@ export function computeSymbolicMetrics(
   c: number = DEFAULT_C,
 ): SymbolicMetrics {
   if (ideas.length === 0) {
-    return { averageV: 0, dominantCluster: null };
+    return { averageV: 0, dominantCluster: null, heatmap: [] };
   }
 
   let sumV = 0;
   const clusterWeights = new Map<string, number>();
 
+  // Lista de valores de v para construir o mapa de calor
+  const valoresV: number[] = [];
+
   for (const idea of ideas) {
     const v = calculateV(idea.w, idea.r, c);
+    valoresV.push(v);
     sumV += v;
     clusterWeights.set(
       idea.context,
@@ -43,9 +48,21 @@ export function computeSymbolicMetrics(
     }
   }
 
+  // Converte a lista linear de v em uma grade quadrada para o heatmap
+  const tamanho = Math.ceil(Math.sqrt(valoresV.length));
+  const heatmap: number[][] = Array.from({ length: tamanho }, () =>
+    Array(tamanho).fill(0),
+  );
+  valoresV.forEach((v, idx) => {
+    const linha = Math.floor(idx / tamanho);
+    const coluna = idx % tamanho;
+    heatmap[linha][coluna] = v;
+  });
+
   return {
     averageV: sumV / ideas.length,
     dominantCluster,
+    heatmap,
   };
 }
 

--- a/eidosdb/tests/logger.test.ts
+++ b/eidosdb/tests/logger.test.ts
@@ -32,11 +32,14 @@ test('calcula média de v e cluster dominante', () => {
 
   expect(metrics.averageV).toBeCloseTo(expectedAvg);
   expect(metrics.dominantCluster).toBe('beta');
+  expect(metrics.heatmap.length).toBe(2);
+  expect(metrics.heatmap[0][0]).toBeCloseTo(calculateV(0.002, 1));
 });
 
 test('retorna métricas neutras quando vazio', () => {
   const metrics = computeSymbolicMetrics([]);
   expect(metrics.averageV).toBe(0);
   expect(metrics.dominantCluster).toBeNull();
+  expect(metrics.heatmap).toEqual([]);
 });
 


### PR DESCRIPTION
## Summary
- add heatmap calculation to symbolic metrics
- embed simple browser and memory heatmap in dashboard
- document interactive dashboard and mark TODO item complete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892bf02c134832f9e43702054779e68