### PR TITLE
feat: add API key generation route

### DIFF
--- a/eidosdb/src/utils/apiKey.ts
+++ b/eidosdb/src/utils/apiKey.ts
@@ -20,6 +20,12 @@ export function obterTier(chave: string): string | undefined {
   return chaves[chave];
 }
 
+/** Adiciona uma nova chave de API e persiste no arquivo. */
+export function adicionarChave(chave: string, tier: string): void {
+  chaves[chave] = tier;
+  fs.writeFileSync(caminho, JSON.stringify(chaves, null, 2));
+}
+
 /** Limites de requisições por minuto para cada tier. */
 export const limitesPorTier: Record<string, number> = {
   basic: 5,


### PR DESCRIPTION
## Summary
- add `/api/keys` endpoint to issue API keys
- persist newly created keys and expose helper utility
- cover API key issuance with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689333a84438832f842119645b0c6257